### PR TITLE
feat(lifecycle): add Kubernetes-style lifecycle hooks

### DIFF
--- a/examples/embedded_job_lifecycle/main.go
+++ b/examples/embedded_job_lifecycle/main.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/loykin/provisr"
+	"github.com/loykin/provisr/internal/job"
+	"github.com/loykin/provisr/internal/process"
+)
+
+// Example demonstrating Job and CronJob with lifecycle hooks
+func main() {
+	fmt.Println("=== Provisr Job Lifecycle Hooks Example ===")
+
+	mgr := provisr.New()
+
+	// Example 1: Data processing job with setup and cleanup hooks
+	dataJobSpec := job.Spec{
+		Name:    "data-processor",
+		Command: "sh -c 'echo \"Processing data...\"; sleep 3; echo \"Data processing completed\"'",
+		Lifecycle: process.LifecycleHooks{
+			PreStart: []process.Hook{
+				{
+					Name:        "download-data",
+					Command:     "echo 'Downloading input data...' && sleep 1",
+					FailureMode: process.FailureModeFail,
+					RunMode:     process.RunModeBlocking,
+				},
+				{
+					Name:        "validate-input",
+					Command:     "echo 'Validating input data...' && sleep 1",
+					FailureMode: process.FailureModeFail,
+					RunMode:     process.RunModeBlocking,
+				},
+			},
+			PostStart: []process.Hook{
+				{
+					Name:        "notify-start",
+					Command:     "echo 'Notifying team that job started...'",
+					FailureMode: process.FailureModeIgnore,
+					RunMode:     process.RunModeAsync,
+				},
+			},
+			PostStop: []process.Hook{
+				{
+					Name:        "upload-results",
+					Command:     "echo 'Uploading results...' && sleep 1",
+					FailureMode: process.FailureModeRetry,
+					RunMode:     process.RunModeBlocking,
+				},
+				{
+					Name:        "cleanup-workspace",
+					Command:     "echo 'Cleaning up workspace...'",
+					FailureMode: process.FailureModeIgnore,
+					RunMode:     process.RunModeBlocking,
+				},
+				{
+					Name:        "notify-completion",
+					Command:     "echo 'Notifying team that job completed...'",
+					FailureMode: process.FailureModeIgnore,
+					RunMode:     process.RunModeAsync,
+				},
+			},
+		},
+	}
+
+	// Create a job manager
+	jobMgr := provisr.NewJobManager(mgr)
+
+	fmt.Println("\n--- Starting data processing job ---")
+	if err := jobMgr.CreateJob(dataJobSpec); err != nil {
+		log.Fatalf("Failed to create job: %v", err)
+	}
+
+	// Monitor job status
+	fmt.Println("\n--- Monitoring job progress ---")
+	for i := 0; i < 10; i++ {
+		status, exists := jobMgr.GetJob("data-processor")
+		if !exists {
+			fmt.Println("Job not found")
+			break
+		}
+
+		fmt.Printf("Job status: %s (Active: %d, Succeeded: %d, Failed: %d)\n",
+			status.Phase, status.Active, status.Succeeded, status.Failed)
+
+		if status.Phase == "Succeeded" || status.Phase == "Failed" {
+			break
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	// Wait a bit more for cleanup hooks to complete
+	time.Sleep(2 * time.Second)
+
+	fmt.Println("\n=== Job Example completed ===")
+}

--- a/examples/embedded_lifecycle_config/main.go
+++ b/examples/embedded_lifecycle_config/main.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/loykin/provisr"
+	"github.com/loykin/provisr/internal/config"
+)
+
+// Example demonstrating lifecycle hooks from configuration file
+func main() {
+	fmt.Println("=== Provisr Lifecycle Configuration Example ===")
+
+	// Get the current directory to find the config file
+	pwd, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("Failed to get current directory: %v", err)
+	}
+
+	configPath := filepath.Join(pwd, "provisr.yaml")
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		// Try relative to the example directory
+		configPath = filepath.Join(filepath.Dir(pwd), "embedded_lifecycle_config", "provisr.yaml")
+	}
+
+	fmt.Printf("Loading configuration from: %s\n", configPath)
+
+	// Load configuration
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		log.Fatalf("Failed to load config: %v", err)
+	}
+
+	// Create manager
+	mgr := provisr.New()
+
+	// Apply configuration
+	if err := mgr.ApplyConfig(cfg.Specs); err != nil {
+		log.Fatalf("Failed to apply config: %v", err)
+	}
+
+	// Set instance groups
+	if len(cfg.GroupSpecs) > 0 {
+		// Convert ServiceGroup to ManagerInstanceGroup (this is a simplified conversion)
+		var instanceGroups []provisr.ManagerInstanceGroup
+		for _, sg := range cfg.GroupSpecs {
+			instanceGroups = append(instanceGroups, provisr.ManagerInstanceGroup{
+				Name:    sg.Name,
+				Members: sg.Members,
+			})
+		}
+		mgr.SetInstanceGroups(instanceGroups)
+	}
+
+	fmt.Println("\n--- Starting web-app with lifecycle hooks ---")
+	if err := mgr.Start("web-app"); err != nil {
+		log.Printf("Failed to start web-app: %v", err)
+	} else {
+		fmt.Println("✓ web-app started successfully")
+	}
+
+	// Wait a moment
+	time.Sleep(3 * time.Second)
+
+	fmt.Println("\n--- Starting background-worker ---")
+	if err := mgr.Start("background-worker"); err != nil {
+		log.Printf("Failed to start background-worker: %v", err)
+	} else {
+		fmt.Println("✓ background-worker started successfully")
+	}
+
+	// Show status
+	fmt.Println("\n--- Process Status ---")
+	if status, err := mgr.Status("web-app"); err == nil {
+		fmt.Printf("web-app: Running=%v, PID=%d\n", status.Running, status.PID)
+	}
+	if status, err := mgr.Status("background-worker"); err == nil {
+		fmt.Printf("background-worker: Running=%v, PID=%d\n", status.Running, status.PID)
+	}
+
+	// Let processes run for a while
+	fmt.Println("\n--- Letting processes run for 5 seconds ---")
+	time.Sleep(5 * time.Second)
+
+	// Stop background worker first
+	fmt.Println("\n--- Stopping background-worker ---")
+	if err := mgr.Stop("background-worker", 10*time.Second); err != nil {
+		log.Printf("Error stopping background-worker: %v", err)
+	} else {
+		fmt.Println("✓ background-worker stopped successfully")
+	}
+
+	// Stop web app
+	fmt.Println("\n--- Stopping web-app ---")
+	if err := mgr.Stop("web-app", 10*time.Second); err != nil {
+		log.Printf("Error stopping web-app: %v", err)
+	} else {
+		fmt.Println("✓ web-app stopped successfully")
+	}
+
+	fmt.Println("\n=== Configuration Example completed ===")
+
+	// Show information about the cronjob that was configured
+	fmt.Println("\nNote: The daily-backup cronjob has been configured but not started.")
+	fmt.Println("It would run daily at 2 AM with its own set of lifecycle hooks.")
+	fmt.Println("CronJob-level hooks are merged with JobTemplate hooks when executed.")
+}

--- a/examples/embedded_lifecycle_config/provisr.yaml
+++ b/examples/embedded_lifecycle_config/provisr.yaml
@@ -1,0 +1,141 @@
+# Provisr configuration with lifecycle hooks examples
+
+processes:
+  # Web application with comprehensive lifecycle hooks
+  - type: process
+    spec:
+      name: web-app
+      command: "python -m http.server 8080"
+      work_dir: "/tmp"
+      instances: 2
+      auto_restart: true
+      lifecycle:
+        pre_start:
+          - name: setup-env
+            command: "echo 'Setting up environment variables'"
+            failure_mode: fail
+            run_mode: blocking
+            timeout: 30s
+          - name: check-port
+            command: "echo 'Checking if port 8080 is available'"
+            failure_mode: fail
+            run_mode: blocking
+          - name: prepare-assets
+            command: "echo 'Preparing static assets'"
+            failure_mode: fail
+            run_mode: blocking
+        post_start:
+          - name: warmup
+            command: "echo 'Warming up application cache'"
+            failure_mode: ignore
+            run_mode: async
+          - name: health-check
+            command: "curl -f http://localhost:8080 || echo 'Health check endpoint not ready yet'"
+            failure_mode: ignore
+            run_mode: blocking
+            timeout: 60s
+        pre_stop:
+          - name: graceful-shutdown
+            command: "echo 'Sending graceful shutdown signal'"
+            failure_mode: ignore
+            run_mode: blocking
+            timeout: 30s
+        post_stop:
+          - name: cleanup-logs
+            command: "echo 'Cleaning up log files'"
+            failure_mode: ignore
+            run_mode: blocking
+          - name: backup-data
+            command: "echo 'Backing up application data'"
+            failure_mode: ignore
+            run_mode: blocking
+
+  # Background worker with retry mechanisms
+  - type: process
+    spec:
+      name: background-worker
+      command: "sh -c 'echo Worker started; sleep 10; echo Worker finished'"
+      auto_restart: false
+      lifecycle:
+        pre_start:
+          - name: connect-queue
+            command: "echo 'Connecting to message queue'"
+            failure_mode: retry
+            run_mode: blocking
+            timeout: 10s
+        post_stop:
+          - name: flush-queue
+            command: "echo 'Flushing remaining messages'"
+            failure_mode: ignore
+            run_mode: blocking
+
+  # Scheduled backup job
+  - type: cronjob
+    spec:
+      name: daily-backup
+      schedule: "0 2 * * *"  # Daily at 2 AM
+      concurrency_policy: Forbid
+      job_template:
+        name: backup-job
+        command: "echo 'Performing database backup'"
+        lifecycle:
+          pre_start:
+            - name: check-disk-space
+              command: "echo 'Checking available disk space'"
+              failure_mode: fail
+              run_mode: blocking
+            - name: lock-database
+              command: "echo 'Acquiring database lock'"
+              failure_mode: fail
+              run_mode: blocking
+          post_start:
+            - name: notify-start
+              command: "echo 'Backup started notification sent'"
+              failure_mode: ignore
+              run_mode: async
+          post_stop:
+            - name: verify-backup
+              command: "echo 'Verifying backup integrity'"
+              failure_mode: retry
+              run_mode: blocking
+            - name: cleanup-temp
+              command: "echo 'Cleaning up temporary files'"
+              failure_mode: ignore
+              run_mode: blocking
+            - name: notify-completion
+              command: "echo 'Backup completion notification sent'"
+              failure_mode: ignore
+              run_mode: async
+      lifecycle:
+        # CronJob-level hooks (applied to each scheduled job)
+        pre_start:
+          - name: check-maintenance-mode
+            command: "echo 'Checking if system is in maintenance mode'"
+            failure_mode: fail
+            run_mode: blocking
+        post_stop:
+          - name: update-metrics
+            command: "echo 'Updating backup metrics'"
+            failure_mode: ignore
+            run_mode: async
+
+# Instance groups for scaling
+groups:
+  - name: web-tier
+    members:
+      - web-app
+  - name: workers
+    members:
+      - background-worker
+
+# Global environment
+env:
+  - "ENVIRONMENT=production"
+  - "LOG_LEVEL=info"
+
+# Logging configuration
+log:
+  dir: "/var/log/provisr"
+  max_size_mb: 100
+  max_backups: 5
+  compress: true

--- a/examples/embedded_lifecycle_failure_modes/main.go
+++ b/examples/embedded_lifecycle_failure_modes/main.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/loykin/provisr"
+	"github.com/loykin/provisr/internal/process"
+)
+
+// Example demonstrating different failure modes in lifecycle hooks
+func main() {
+	fmt.Println("=== Provisr Lifecycle Failure Modes Example ===")
+
+	mgr := provisr.New()
+
+	// Example 1: Process with failing pre-start hook (fail mode)
+	fmt.Println("\n=== Example 1: Fail Mode Hook ===")
+	failProcessSpec := provisr.Spec{
+		Name:    "fail-process",
+		Command: "echo 'This process should not start'",
+		Lifecycle: process.LifecycleHooks{
+			PreStart: []process.Hook{
+				{
+					Name:        "failing-setup",
+					Command:     "echo 'Setup failing...' && exit 1", // This will fail
+					FailureMode: process.FailureModeFail,             // Stop process start on failure
+					RunMode:     process.RunModeBlocking,
+				},
+			},
+		},
+	}
+
+	if err := mgr.Register(failProcessSpec); err != nil {
+		log.Fatalf("Failed to register fail-process: %v", err)
+	}
+
+	fmt.Println("Attempting to start process with failing pre-start hook...")
+	if err := mgr.Start("fail-process"); err != nil {
+		fmt.Printf("✓ Expected failure: %v\n", err)
+	} else {
+		fmt.Println("✗ Process started unexpectedly!")
+	}
+
+	// Example 2: Process with failing hook but ignore mode
+	fmt.Println("\n=== Example 2: Ignore Mode Hook ===")
+	ignoreProcessSpec := provisr.Spec{
+		Name:    "ignore-process",
+		Command: "sh -c 'echo \"Process started despite hook failure\"; sleep 2'",
+		Lifecycle: process.LifecycleHooks{
+			PreStart: []process.Hook{
+				{
+					Name:        "optional-setup",
+					Command:     "echo 'Optional setup failing...' && exit 1", // This will fail
+					FailureMode: process.FailureModeIgnore,                    // Continue despite failure
+					RunMode:     process.RunModeBlocking,
+				},
+			},
+			PostStop: []process.Hook{
+				{
+					Name:        "optional-cleanup",
+					Command:     "echo 'Optional cleanup failing...' && exit 1", // This will also fail
+					FailureMode: process.FailureModeIgnore,                      // Continue despite failure
+					RunMode:     process.RunModeBlocking,
+				},
+			},
+		},
+	}
+
+	if err := mgr.Register(ignoreProcessSpec); err != nil {
+		log.Fatalf("Failed to register ignore-process: %v", err)
+	}
+
+	fmt.Println("Starting process with failing pre-start hook (ignore mode)...")
+	if err := mgr.Start("ignore-process"); err != nil {
+		fmt.Printf("✗ Unexpected failure: %v\n", err)
+	} else {
+		fmt.Println("✓ Process started successfully despite hook failure")
+	}
+
+	// Let it run briefly
+	time.Sleep(3 * time.Second)
+
+	fmt.Println("Stopping process (will have failing post-stop hook with ignore mode)...")
+	if err := mgr.Stop("ignore-process", 5*time.Second); err != nil {
+		fmt.Printf("✗ Unexpected stop failure: %v\n", err)
+	} else {
+		fmt.Println("✓ Process stopped successfully despite hook failure")
+	}
+
+	// Example 3: Process with retry mode hook
+	fmt.Println("\n=== Example 3: Retry Mode Hook ===")
+	retryProcessSpec := provisr.Spec{
+		Name:    "retry-process",
+		Command: "sh -c 'echo \"Process with retry hooks\"; sleep 3'",
+		Lifecycle: process.LifecycleHooks{
+			PreStart: []process.Hook{
+				{
+					Name:        "flaky-setup",
+					Command:     "echo 'Attempting flaky setup...' && if [ $RANDOM -gt 16384 ]; then exit 1; else echo 'Setup succeeded'; fi",
+					FailureMode: process.FailureModeRetry, // Retry once on failure
+					RunMode:     process.RunModeBlocking,
+					Timeout:     5 * time.Second,
+				},
+			},
+		},
+	}
+
+	if err := mgr.Register(retryProcessSpec); err != nil {
+		log.Fatalf("Failed to register retry-process: %v", err)
+	}
+
+	fmt.Println("Starting process with retry-mode hook (may retry on failure)...")
+	if err := mgr.Start("retry-process"); err != nil {
+		fmt.Printf("Process failed to start after retry: %v\n", err)
+	} else {
+		fmt.Println("✓ Process started (setup succeeded or succeeded after retry)")
+	}
+
+	// Let it run briefly
+	time.Sleep(4 * time.Second)
+
+	fmt.Println("Stopping retry process...")
+	if err := mgr.Stop("retry-process", 5*time.Second); err != nil {
+		fmt.Printf("Error stopping retry-process: %v\n", err)
+	}
+
+	// Example 4: Async hooks that don't block
+	fmt.Println("\n=== Example 4: Async vs Blocking Hooks ===")
+	asyncProcessSpec := provisr.Spec{
+		Name:    "async-process",
+		Command: "sh -c 'echo \"Process with async hooks\"; sleep 2'",
+		Lifecycle: process.LifecycleHooks{
+			PostStart: []process.Hook{
+				{
+					Name:        "slow-notification",
+					Command:     "sh -c 'echo \"Starting slow notification...\"; sleep 3; echo \"Notification sent\"'",
+					FailureMode: process.FailureModeIgnore,
+					RunMode:     process.RunModeAsync, // Don't block process start
+					Timeout:     10 * time.Second,
+				},
+				{
+					Name:        "quick-log",
+					Command:     "echo 'Quick log entry created'",
+					FailureMode: process.FailureModeIgnore,
+					RunMode:     process.RunModeBlocking, // Block briefly for logging
+				},
+			},
+		},
+	}
+
+	if err := mgr.Register(asyncProcessSpec); err != nil {
+		log.Fatalf("Failed to register async-process: %v", err)
+	}
+
+	fmt.Println("Starting process with async post-start hook...")
+	start := time.Now()
+	if err := mgr.Start("async-process"); err != nil {
+		fmt.Printf("Failed to start async-process: %v\n", err)
+	} else {
+		duration := time.Since(start)
+		fmt.Printf("✓ Process started in %v (async hook didn't block)\n", duration)
+	}
+
+	// Let everything finish
+	time.Sleep(5 * time.Second)
+
+	fmt.Println("Stopping async process...")
+	if err := mgr.Stop("async-process", 5*time.Second); err != nil {
+		fmt.Printf("Error stopping async-process: %v\n", err)
+	}
+
+	fmt.Println("\n=== Failure Modes Example completed ===")
+	fmt.Println("\nSummary of failure modes:")
+	fmt.Println("- fail: Stop the operation if hook fails")
+	fmt.Println("- ignore: Continue despite hook failure")
+	fmt.Println("- retry: Retry the hook once, then fail if still failing")
+	fmt.Println("\nSummary of run modes:")
+	fmt.Println("- blocking: Wait for hook to complete before continuing")
+	fmt.Println("- async: Start hook and continue immediately")
+}

--- a/examples/embedded_lifecycle_hooks/main.go
+++ b/examples/embedded_lifecycle_hooks/main.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/loykin/provisr"
+	"github.com/loykin/provisr/internal/process"
+)
+
+// Example demonstrating lifecycle hooks functionality
+// This shows how to use pre_start, post_start, pre_stop, and post_stop hooks
+func main() {
+	fmt.Println("=== Provisr Lifecycle Hooks Example ===")
+
+	mgr := provisr.New()
+
+	// Example 1: Web server with database setup hooks
+	webServerSpec := provisr.Spec{
+		Name:    "web-server",
+		Command: "sh -c 'echo \"Web server starting...\"; sleep 3; echo \"Web server running on port 8080\"; sleep 5; echo \"Web server shutting down\"'",
+		Lifecycle: process.LifecycleHooks{
+			PreStart: []process.Hook{
+				{
+					Name:        "check-dependencies",
+					Command:     "echo 'Checking dependencies...' && sleep 1",
+					FailureMode: process.FailureModeFail,
+					RunMode:     process.RunModeBlocking,
+				},
+				{
+					Name:        "setup-database",
+					Command:     "echo 'Setting up database connection...' && sleep 1",
+					FailureMode: process.FailureModeFail,
+					RunMode:     process.RunModeBlocking,
+				},
+				{
+					Name:        "migrate-schema",
+					Command:     "echo 'Running database migrations...' && sleep 1",
+					FailureMode: process.FailureModeFail,
+					RunMode:     process.RunModeBlocking,
+				},
+			},
+			PostStart: []process.Hook{
+				{
+					Name:        "health-check",
+					Command:     "echo 'Performing health check...' && sleep 1 && echo 'Health check passed'",
+					FailureMode: process.FailureModeIgnore, // Don't fail if health check fails
+					RunMode:     process.RunModeBlocking,
+					Timeout:     10 * time.Second,
+				},
+				{
+					Name:        "register-service",
+					Command:     "echo 'Registering service in service discovery...'",
+					FailureMode: process.FailureModeIgnore,
+					RunMode:     process.RunModeAsync, // Don't block on service registration
+				},
+			},
+			PreStop: []process.Hook{
+				{
+					Name:        "drain-connections",
+					Command:     "echo 'Draining active connections...' && sleep 2",
+					FailureMode: process.FailureModeIgnore, // Continue shutdown even if drain fails
+					RunMode:     process.RunModeBlocking,
+					Timeout:     30 * time.Second,
+				},
+			},
+			PostStop: []process.Hook{
+				{
+					Name:        "cleanup-temp-files",
+					Command:     "echo 'Cleaning up temporary files...' && sleep 1",
+					FailureMode: process.FailureModeIgnore,
+					RunMode:     process.RunModeBlocking,
+				},
+				{
+					Name:        "deregister-service",
+					Command:     "echo 'Deregistering service from service discovery...'",
+					FailureMode: process.FailureModeIgnore,
+					RunMode:     process.RunModeBlocking,
+				},
+			},
+		},
+	}
+
+	// Register the process
+	if err := mgr.Register(webServerSpec); err != nil {
+		log.Fatalf("Failed to register web server: %v", err)
+	}
+
+	fmt.Println("\n--- Starting web server with lifecycle hooks ---")
+	if err := mgr.Start("web-server"); err != nil {
+		log.Fatalf("Failed to start web server: %v", err)
+	}
+
+	// Let it run for a while
+	fmt.Println("\n--- Web server is running, waiting 8 seconds ---")
+	time.Sleep(8 * time.Second)
+
+	// Stop the process
+	fmt.Println("\n--- Stopping web server with lifecycle hooks ---")
+	if err := mgr.Stop("web-server", 10*time.Second); err != nil {
+		log.Printf("Error stopping web server: %v", err)
+	}
+
+	fmt.Println("\n=== Example completed ===")
+}

--- a/internal/cronjob/lifecycle_test.go
+++ b/internal/cronjob/lifecycle_test.go
@@ -1,0 +1,272 @@
+package cronjob
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/loykin/provisr/internal/job"
+	"github.com/loykin/provisr/internal/process"
+)
+
+func TestCronJobSpec_WithLifecycleHooks(t *testing.T) {
+	spec := CronJobSpec{
+		Name:     "test-cronjob",
+		Schedule: "0 0 * * *", // Daily at midnight
+		JobTemplate: job.Spec{
+			Name:    "template-job",
+			Command: "echo 'job from cronjob'",
+			Lifecycle: process.LifecycleHooks{
+				PreStart: []process.Hook{
+					{
+						Name:        "job-setup",
+						Command:     "echo 'job-level setup'",
+						FailureMode: process.FailureModeFail,
+					},
+				},
+			},
+		},
+		Lifecycle: process.LifecycleHooks{
+			PreStart: []process.Hook{
+				{
+					Name:        "cronjob-setup",
+					Command:     "echo 'cronjob-level setup'",
+					FailureMode: process.FailureModeFail,
+				},
+			},
+			PostStop: []process.Hook{
+				{
+					Name:        "cronjob-cleanup",
+					Command:     "echo 'cronjob-level cleanup'",
+					FailureMode: process.FailureModeIgnore,
+				},
+			},
+		},
+	}
+
+	// Apply defaults and test validation
+	spec.GetDefaults()
+	err := spec.Validate()
+	if err != nil {
+		t.Errorf("CronJobSpec.Validate() failed: %v", err)
+	}
+
+	// Test job creation from template
+	jobSpec := spec.CreateJobFromTemplate("test-job-instance")
+
+	if jobSpec.Name != "test-job-instance" {
+		t.Errorf("CreateJobFromTemplate() Name = %v, want test-job-instance", jobSpec.Name)
+	}
+
+	// Test lifecycle hooks are merged (CronJob hooks should come first)
+	if len(jobSpec.Lifecycle.PreStart) != 2 {
+		t.Errorf("CreateJobFromTemplate() PreStart hooks count = %d, want 2", len(jobSpec.Lifecycle.PreStart))
+	}
+
+	// CronJob hooks should come first
+	if jobSpec.Lifecycle.PreStart[0].Name != "cronjob-setup" {
+		t.Errorf("CreateJobFromTemplate() first PreStart hook = %v, want cronjob-setup", jobSpec.Lifecycle.PreStart[0].Name)
+	}
+	if jobSpec.Lifecycle.PreStart[1].Name != "job-setup" {
+		t.Errorf("CreateJobFromTemplate() second PreStart hook = %v, want job-setup", jobSpec.Lifecycle.PreStart[1].Name)
+	}
+
+	// Test PostStop hooks from CronJob level
+	if len(jobSpec.Lifecycle.PostStop) != 1 {
+		t.Errorf("CreateJobFromTemplate() PostStop hooks count = %d, want 1", len(jobSpec.Lifecycle.PostStop))
+	}
+	if jobSpec.Lifecycle.PostStop[0].Name != "cronjob-cleanup" {
+		t.Errorf("CreateJobFromTemplate() PostStop hook = %v, want cronjob-cleanup", jobSpec.Lifecycle.PostStop[0].Name)
+	}
+}
+
+func TestCronJobSpec_LifecycleValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cronjob CronJobSpec
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid cronjob with lifecycle",
+			cronjob: CronJobSpec{
+				Name:     "valid-cronjob",
+				Schedule: "0 0 * * *",
+				JobTemplate: job.Spec{
+					Name:    "template",
+					Command: "echo test",
+				},
+				Lifecycle: process.LifecycleHooks{
+					PreStart: []process.Hook{
+						{Name: "setup", Command: "echo setup"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid lifecycle hooks",
+			cronjob: CronJobSpec{
+				Name:     "invalid-cronjob",
+				Schedule: "0 0 * * *",
+				JobTemplate: job.Spec{
+					Name:    "template",
+					Command: "echo test",
+				},
+				Lifecycle: process.LifecycleHooks{
+					PreStart: []process.Hook{
+						{Name: "", Command: "echo test"}, // Invalid: empty name
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "lifecycle validation failed",
+		},
+		{
+			name: "invalid job template with lifecycle",
+			cronjob: CronJobSpec{
+				Name:     "invalid-template-cronjob",
+				Schedule: "0 0 * * *",
+				JobTemplate: job.Spec{
+					Name:    "template",
+					Command: "echo test",
+					Lifecycle: process.LifecycleHooks{
+						PreStart: []process.Hook{
+							{Name: "dup", Command: "echo test1"},
+						},
+						PostStart: []process.Hook{
+							{Name: "dup", Command: "echo test2"}, // Duplicate name
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid job template",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.cronjob.GetDefaults()
+			err := tt.cronjob.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("CronJobSpec.Validate() error = nil, wantErr %v", tt.wantErr)
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("CronJobSpec.Validate() error = %v, want to contain %v", err, tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("CronJobSpec.Validate() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestCronJobSpec_CreateJobFromTemplate_NoLifecycleHooks(t *testing.T) {
+	spec := CronJobSpec{
+		Name:     "simple-cronjob",
+		Schedule: "0 0 * * *",
+		JobTemplate: job.Spec{
+			Name:    "template-job",
+			Command: "echo 'simple job'",
+		},
+		// No lifecycle hooks at CronJob level
+	}
+
+	jobSpec := spec.CreateJobFromTemplate("simple-job-instance")
+
+	if jobSpec.Name != "simple-job-instance" {
+		t.Errorf("CreateJobFromTemplate() Name = %v, want simple-job-instance", jobSpec.Name)
+	}
+
+	// Should have no lifecycle hooks
+	if jobSpec.Lifecycle.HasAnyHooks() {
+		t.Error("CreateJobFromTemplate() should have no lifecycle hooks for simple cronjob")
+	}
+}
+
+func TestCronJobSpec_CreateJobFromTemplate_OnlyJobTemplateHooks(t *testing.T) {
+	spec := CronJobSpec{
+		Name:     "template-hooks-cronjob",
+		Schedule: "0 0 * * *",
+		JobTemplate: job.Spec{
+			Name:    "template-job",
+			Command: "echo 'job with hooks'",
+			Lifecycle: process.LifecycleHooks{
+				PreStart: []process.Hook{
+					{Name: "template-setup", Command: "echo 'template setup'"},
+				},
+			},
+		},
+		// No lifecycle hooks at CronJob level
+	}
+
+	jobSpec := spec.CreateJobFromTemplate("template-job-instance")
+
+	// Should have only JobTemplate hooks
+	if len(jobSpec.Lifecycle.PreStart) != 1 {
+		t.Errorf("CreateJobFromTemplate() PreStart hooks count = %d, want 1", len(jobSpec.Lifecycle.PreStart))
+	}
+	if jobSpec.Lifecycle.PreStart[0].Name != "template-setup" {
+		t.Errorf("CreateJobFromTemplate() PreStart hook = %v, want template-setup", jobSpec.Lifecycle.PreStart[0].Name)
+	}
+}
+
+func TestCronJobSpec_CreateJobFromTemplate_HookMerging(t *testing.T) {
+	spec := CronJobSpec{
+		Name:     "merging-cronjob",
+		Schedule: "*/5 * * * *", // Every 5 minutes
+		JobTemplate: job.Spec{
+			Name:    "template-job",
+			Command: "echo 'merging job'",
+			Lifecycle: process.LifecycleHooks{
+				PreStart: []process.Hook{
+					{Name: "template-pre", Command: "echo 'template pre'"},
+				},
+				PostStart: []process.Hook{
+					{Name: "template-post", Command: "echo 'template post'"},
+				},
+			},
+		},
+		Lifecycle: process.LifecycleHooks{
+			PreStart: []process.Hook{
+				{Name: "cronjob-pre", Command: "echo 'cronjob pre'"},
+			},
+			PreStop: []process.Hook{
+				{Name: "cronjob-stop", Command: "echo 'cronjob stop'"},
+			},
+		},
+	}
+
+	jobSpec := spec.CreateJobFromTemplate("merged-job-instance")
+
+	// Test PreStart merging (CronJob first, then JobTemplate)
+	if len(jobSpec.Lifecycle.PreStart) != 2 {
+		t.Errorf("CreateJobFromTemplate() PreStart hooks count = %d, want 2", len(jobSpec.Lifecycle.PreStart))
+	}
+	if jobSpec.Lifecycle.PreStart[0].Name != "cronjob-pre" {
+		t.Errorf("CreateJobFromTemplate() first PreStart hook = %v, want cronjob-pre", jobSpec.Lifecycle.PreStart[0].Name)
+	}
+	if jobSpec.Lifecycle.PreStart[1].Name != "template-pre" {
+		t.Errorf("CreateJobFromTemplate() second PreStart hook = %v, want template-pre", jobSpec.Lifecycle.PreStart[1].Name)
+	}
+
+	// Test PostStart (only from JobTemplate)
+	if len(jobSpec.Lifecycle.PostStart) != 1 {
+		t.Errorf("CreateJobFromTemplate() PostStart hooks count = %d, want 1", len(jobSpec.Lifecycle.PostStart))
+	}
+	if jobSpec.Lifecycle.PostStart[0].Name != "template-post" {
+		t.Errorf("CreateJobFromTemplate() PostStart hook = %v, want template-post", jobSpec.Lifecycle.PostStart[0].Name)
+	}
+
+	// Test PreStop (only from CronJob)
+	if len(jobSpec.Lifecycle.PreStop) != 1 {
+		t.Errorf("CreateJobFromTemplate() PreStop hooks count = %d, want 1", len(jobSpec.Lifecycle.PreStop))
+	}
+	if jobSpec.Lifecycle.PreStop[0].Name != "cronjob-stop" {
+		t.Errorf("CreateJobFromTemplate() PreStop hook = %v, want cronjob-stop", jobSpec.Lifecycle.PreStop[0].Name)
+	}
+}

--- a/internal/job/lifecycle_test.go
+++ b/internal/job/lifecycle_test.go
@@ -1,0 +1,196 @@
+package job
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/loykin/provisr/internal/process"
+)
+
+func TestJobSpec_WithLifecycleHooks(t *testing.T) {
+	spec := Spec{
+		Name:    "test-job",
+		Command: "echo 'job running'",
+		Lifecycle: process.LifecycleHooks{
+			PreStart: []process.Hook{
+				{
+					Name:        "setup",
+					Command:     "echo 'job setup'",
+					FailureMode: process.FailureModeFail,
+				},
+			},
+			PostStop: []process.Hook{
+				{
+					Name:        "cleanup",
+					Command:     "echo 'job cleanup'",
+					FailureMode: process.FailureModeIgnore,
+				},
+			},
+		},
+	}
+
+	// Test validation
+	err := spec.Validate()
+	if err != nil {
+		t.Errorf("JobSpec.Validate() failed: %v", err)
+	}
+
+	// Test conversion to ProcessSpec
+	processSpec := spec.ToProcessSpec()
+	if processSpec.Name != spec.Name {
+		t.Errorf("ToProcessSpec() Name = %v, want %v", processSpec.Name, spec.Name)
+	}
+	if processSpec.Command != spec.Command {
+		t.Errorf("ToProcessSpec() Command = %v, want %v", processSpec.Command, spec.Command)
+	}
+
+	// Test lifecycle hooks are copied
+	if len(processSpec.Lifecycle.PreStart) != 1 {
+		t.Errorf("ToProcessSpec() PreStart hooks count = %d, want 1", len(processSpec.Lifecycle.PreStart))
+	}
+	if len(processSpec.Lifecycle.PostStop) != 1 {
+		t.Errorf("ToProcessSpec() PostStop hooks count = %d, want 1", len(processSpec.Lifecycle.PostStop))
+	}
+
+	if processSpec.Lifecycle.PreStart[0].Name != "setup" {
+		t.Errorf("ToProcessSpec() PreStart hook name = %v, want setup", processSpec.Lifecycle.PreStart[0].Name)
+	}
+}
+
+func TestJobSpec_LifecycleValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		lifecycle process.LifecycleHooks
+		wantErr   bool
+		errMsg    string
+	}{
+		{
+			name: "valid lifecycle",
+			lifecycle: process.LifecycleHooks{
+				PreStart: []process.Hook{
+					{Name: "setup", Command: "echo setup"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid hook in lifecycle",
+			lifecycle: process.LifecycleHooks{
+				PreStart: []process.Hook{
+					{Name: "", Command: "echo test"}, // Invalid: empty name
+				},
+			},
+			wantErr: true,
+			errMsg:  "lifecycle validation failed",
+		},
+		{
+			name: "duplicate hook names",
+			lifecycle: process.LifecycleHooks{
+				PreStart: []process.Hook{
+					{Name: "hook1", Command: "echo test1"},
+				},
+				PostStart: []process.Hook{
+					{Name: "hook1", Command: "echo test2"}, // Duplicate name
+				},
+			},
+			wantErr: true,
+			errMsg:  "duplicate hook name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := Spec{
+				Name:      "test-job",
+				Command:   "echo test",
+				Lifecycle: tt.lifecycle,
+			}
+
+			err := spec.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("JobSpec.Validate() error = nil, wantErr %v", tt.wantErr)
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("JobSpec.Validate() error = %v, want to contain %v", err, tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("JobSpec.Validate() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestJobSpec_LifecycleWithJobSettings(t *testing.T) {
+	parallelism := int32(2)
+	backoffLimit := int32(3)
+
+	spec := Spec{
+		Name:          "parallel-job",
+		Command:       "echo 'parallel job'",
+		Parallelism:   &parallelism,
+		BackoffLimit:  &backoffLimit,
+		RestartPolicy: string(RestartPolicyOnFailure),
+		Lifecycle: process.LifecycleHooks{
+			PreStart: []process.Hook{
+				{
+					Name:        "parallel-setup",
+					Command:     "echo 'setting up parallel job'",
+					FailureMode: process.FailureModeFail,
+				},
+			},
+		},
+	}
+
+	err := spec.Validate()
+	if err != nil {
+		t.Errorf("JobSpec.Validate() failed: %v", err)
+	}
+
+	processSpec := spec.ToProcessSpec()
+
+	// Test that job settings are preserved
+	if processSpec.Instances != int(parallelism) {
+		t.Errorf("ToProcessSpec() Instances = %d, want %d", processSpec.Instances, parallelism)
+	}
+	if processSpec.RetryCount != uint32(backoffLimit) {
+		t.Errorf("ToProcessSpec() RetryCount = %d, want %d", processSpec.RetryCount, backoffLimit)
+	}
+	if !processSpec.AutoRestart {
+		t.Error("ToProcessSpec() AutoRestart = false, want true for OnFailure restart policy")
+	}
+
+	// Test that lifecycle hooks are preserved
+	if len(processSpec.Lifecycle.PreStart) != 1 {
+		t.Errorf("ToProcessSpec() PreStart hooks count = %d, want 1", len(processSpec.Lifecycle.PreStart))
+	}
+}
+
+func TestJobSpec_LifecycleDeepCopy(t *testing.T) {
+	original := Spec{
+		Name:    "original-job",
+		Command: "echo original",
+		Lifecycle: process.LifecycleHooks{
+			PreStart: []process.Hook{
+				{
+					Name:    "setup",
+					Command: "echo setup",
+					Env:     []string{"TEST=original"},
+				},
+			},
+		},
+	}
+
+	processSpec := original.ToProcessSpec()
+
+	// Modify the original
+	original.Lifecycle.PreStart[0].Env[0] = "TEST=modified"
+
+	// Verify the process spec is not affected (deep copy worked)
+	if processSpec.Lifecycle.PreStart[0].Env[0] == "TEST=modified" {
+		t.Error("ToProcessSpec() did not create deep copy of lifecycle hooks")
+	}
+}

--- a/internal/manager/lifecycle_test.go
+++ b/internal/manager/lifecycle_test.go
@@ -290,8 +290,6 @@ func TestManagedProcess_HookFailureInPreStart(t *testing.T) {
 
 	if err != nil && !strings.Contains(err.Error(), "pre_start hooks failed") {
 		t.Errorf("Error should mention pre_start hooks failure, got: %v", err)
-	} else if err != nil {
-		t.Errorf("Error should mention pre_start hooks failure, got: %v", err)
 	}
 
 	// Process should be stopped

--- a/internal/manager/lifecycle_test.go
+++ b/internal/manager/lifecycle_test.go
@@ -1,0 +1,342 @@
+package manager
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/loykin/provisr/internal/process"
+)
+
+func TestManagedProcess_ExecuteLifecycleHooks(t *testing.T) {
+	envMerger := func(spec process.Spec) []string {
+		return spec.Env
+	}
+
+	spec := process.Spec{
+		Name:    "test-process",
+		Command: "echo 'test process'",
+		Lifecycle: process.LifecycleHooks{
+			PreStart: []process.Hook{
+				{
+					Name:        "pre-hook",
+					Command:     "echo 'pre-start hook executed'",
+					FailureMode: process.FailureModeFail,
+					RunMode:     process.RunModeBlocking,
+				},
+			},
+			PostStart: []process.Hook{
+				{
+					Name:        "post-hook",
+					Command:     "echo 'post-start hook executed'",
+					FailureMode: process.FailureModeIgnore,
+					RunMode:     process.RunModeBlocking,
+				},
+			},
+		},
+	}
+
+	mp := NewManagedProcess(spec, envMerger)
+
+	// Test pre-start hooks
+	err := mp.executeLifecycleHooks(spec, process.PhasePreStart)
+	if err != nil {
+		t.Errorf("executeLifecycleHooks(PreStart) failed: %v", err)
+	}
+
+	// Test post-start hooks
+	err = mp.executeLifecycleHooks(spec, process.PhasePostStart)
+	if err != nil {
+		t.Errorf("executeLifecycleHooks(PostStart) failed: %v", err)
+	}
+
+	// Test with no hooks
+	emptySpec := process.Spec{
+		Name:    "empty-process",
+		Command: "echo test",
+	}
+	err = mp.executeLifecycleHooks(emptySpec, process.PhasePreStart)
+	if err != nil {
+		t.Errorf("executeLifecycleHooks with no hooks failed: %v", err)
+	}
+
+	_ = mp.Shutdown()
+}
+
+func TestManagedProcess_ExecuteHookFailureModes(t *testing.T) {
+	envMerger := func(spec process.Spec) []string {
+		return spec.Env
+	}
+
+	tests := []struct {
+		name        string
+		hook        process.Hook
+		expectError bool
+	}{
+		{
+			name: "success hook",
+			hook: process.Hook{
+				Name:        "success",
+				Command:     "echo 'success'",
+				FailureMode: process.FailureModeFail,
+			},
+			expectError: false,
+		},
+		{
+			name: "failing hook with ignore mode",
+			hook: process.Hook{
+				Name:        "fail-ignore",
+				Command:     "exit 1",
+				FailureMode: process.FailureModeIgnore,
+			},
+			expectError: false,
+		},
+		{
+			name: "failing hook with fail mode",
+			hook: process.Hook{
+				Name:        "fail-fail",
+				Command:     "exit 1",
+				FailureMode: process.FailureModeFail,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := process.Spec{
+				Name:    "test-process",
+				Command: "echo test",
+				Lifecycle: process.LifecycleHooks{
+					PreStart: []process.Hook{tt.hook},
+				},
+			}
+
+			mp := NewManagedProcess(spec, envMerger)
+			err := mp.executeLifecycleHooks(spec, process.PhasePreStart)
+
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+
+			_ = mp.Shutdown()
+		})
+	}
+}
+
+func TestManagedProcess_ExecuteHookWithTimeout(t *testing.T) {
+	envMerger := func(spec process.Spec) []string {
+		return spec.Env
+	}
+
+	// Test hook that should timeout
+	spec := process.Spec{
+		Name:    "test-process",
+		Command: "echo test",
+		Lifecycle: process.LifecycleHooks{
+			PreStart: []process.Hook{
+				{
+					Name:        "timeout-hook",
+					Command:     "sleep 2",
+					Timeout:     100 * time.Millisecond,
+					FailureMode: process.FailureModeFail,
+				},
+			},
+		},
+	}
+
+	mp := NewManagedProcess(spec, envMerger)
+	start := time.Now()
+	err := mp.executeLifecycleHooks(spec, process.PhasePreStart)
+	duration := time.Since(start)
+
+	if err == nil {
+		t.Error("Expected timeout error but got none")
+	}
+
+	// Should complete in around timeout duration, not the full sleep duration
+	if duration > 1*time.Second {
+		t.Errorf("Hook took too long to timeout: %v", duration)
+	}
+
+	_ = mp.Shutdown()
+}
+
+func TestManagedProcess_ExecuteHookEnvironmentVariables(t *testing.T) {
+	envMerger := func(spec process.Spec) []string {
+		return append(spec.Env, "GLOBAL_VAR=global_value")
+	}
+
+	// Create a hook that prints environment variables
+	spec := process.Spec{
+		Name:    "test-process",
+		Command: "echo test",
+		Env:     []string{"PROCESS_VAR=process_value"},
+		Lifecycle: process.LifecycleHooks{
+			PreStart: []process.Hook{
+				{
+					Name:    "env-test",
+					Command: "env | grep -E '(PROVISR_|PROCESS_|HOOK_)'",
+					Env:     []string{"HOOK_VAR=hook_value"},
+				},
+			},
+		},
+	}
+
+	mp := NewManagedProcess(spec, envMerger)
+
+	// This should not fail - environment variables should be properly set
+	err := mp.executeLifecycleHooks(spec, process.PhasePreStart)
+	if err != nil {
+		t.Errorf("executeLifecycleHooks failed: %v", err)
+	}
+
+	_ = mp.Shutdown()
+}
+
+func TestManagedProcess_HookIntegrationWithStartStop(t *testing.T) {
+	envMerger := func(spec process.Spec) []string {
+		return spec.Env
+	}
+
+	// Create a spec with hooks that create/remove a test file
+	testFile := "/tmp/provisr_hook_test"
+
+	spec := process.Spec{
+		Name:    "hook-integration-test",
+		Command: "sleep 0.5", // Short-lived process
+		Lifecycle: process.LifecycleHooks{
+			PreStart: []process.Hook{
+				{
+					Name:        "create-file",
+					Command:     "touch " + testFile,
+					FailureMode: process.FailureModeFail,
+				},
+			},
+			PostStart: []process.Hook{
+				{
+					Name:        "verify-file",
+					Command:     "test -f " + testFile,
+					FailureMode: process.FailureModeFail,
+				},
+			},
+			PreStop: []process.Hook{
+				{
+					Name:        "pre-cleanup",
+					Command:     "echo 'cleaning up'",
+					FailureMode: process.FailureModeIgnore,
+				},
+			},
+			PostStop: []process.Hook{
+				{
+					Name:        "remove-file",
+					Command:     "rm -f " + testFile,
+					FailureMode: process.FailureModeIgnore,
+				},
+			},
+		},
+	}
+
+	mp := NewManagedProcess(spec, envMerger)
+
+	// Start the process (this should trigger pre and post start hooks)
+	err := mp.Start(spec)
+	if err != nil {
+		t.Fatalf("Failed to start process: %v", err)
+	}
+
+	// Wait a bit for the process to run
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop the process (this should trigger pre and post stop hooks)
+	err = mp.Stop(2 * time.Second)
+	if err != nil {
+		t.Errorf("Failed to stop process: %v", err)
+	}
+
+	// Cleanup in case hooks failed
+	_ = mp.Shutdown()
+}
+
+func TestManagedProcess_HookFailureInPreStart(t *testing.T) {
+	envMerger := func(spec process.Spec) []string {
+		return spec.Env
+	}
+
+	spec := process.Spec{
+		Name:    "failing-prestart-test",
+		Command: "echo 'should not run'",
+		Lifecycle: process.LifecycleHooks{
+			PreStart: []process.Hook{
+				{
+					Name:        "failing-hook",
+					Command:     "exit 1",
+					FailureMode: process.FailureModeFail,
+				},
+			},
+		},
+	}
+
+	mp := NewManagedProcess(spec, envMerger)
+
+	// Start should fail due to pre-start hook failure
+	err := mp.Start(spec)
+	if err == nil {
+		t.Error("Expected start to fail due to pre-start hook failure")
+	}
+
+	if err != nil && !strings.Contains(err.Error(), "pre_start hooks failed") {
+		t.Errorf("Error should mention pre_start hooks failure, got: %v", err)
+	} else if err != nil {
+		t.Errorf("Error should mention pre_start hooks failure, got: %v", err)
+	}
+
+	// Process should be stopped
+	status := mp.Status()
+	if status.Running {
+		t.Error("Process should not be running after pre-start hook failure")
+	}
+
+	_ = mp.Shutdown()
+}
+
+func TestManagedProcess_AsyncHookExecution(t *testing.T) {
+	envMerger := func(spec process.Spec) []string {
+		return spec.Env
+	}
+
+	spec := process.Spec{
+		Name:    "async-hook-test",
+		Command: "echo test",
+		Lifecycle: process.LifecycleHooks{
+			PostStart: []process.Hook{
+				{
+					Name:    "async-hook",
+					Command: "sleep 0.1 && echo 'async completed'",
+					RunMode: process.RunModeAsync,
+				},
+			},
+		},
+	}
+
+	mp := NewManagedProcess(spec, envMerger)
+
+	// Async hooks should not block execution
+	start := time.Now()
+	err := mp.executeLifecycleHooks(spec, process.PhasePostStart)
+	duration := time.Since(start)
+
+	if err != nil {
+		t.Errorf("Async hook execution failed: %v", err)
+	}
+
+	// Should complete quickly since it's async
+	if duration > 50*time.Millisecond {
+		t.Errorf("Async hook took too long: %v", duration)
+	}
+
+	_ = mp.Shutdown()
+}

--- a/internal/process/lifecycle.go
+++ b/internal/process/lifecycle.go
@@ -1,0 +1,271 @@
+package process
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// LifecycleHooks defines hooks that run at different stages of process lifecycle
+type LifecycleHooks struct {
+	PreStart  []Hook `json:"pre_start" mapstructure:"pre_start"`   // Before process starts
+	PostStart []Hook `json:"post_start" mapstructure:"post_start"` // After process starts successfully
+	PreStop   []Hook `json:"pre_stop" mapstructure:"pre_stop"`     // Before process stops
+	PostStop  []Hook `json:"post_stop" mapstructure:"post_stop"`   // After process stops
+}
+
+// Hook represents a single lifecycle hook command
+type Hook struct {
+	Name        string        `json:"name" mapstructure:"name"`                 // Hook name for identification
+	Command     string        `json:"command" mapstructure:"command"`           // Command to execute
+	WorkDir     string        `json:"work_dir" mapstructure:"work_dir"`         // Working directory (optional)
+	Env         []string      `json:"env" mapstructure:"env"`                   // Additional environment variables
+	Timeout     time.Duration `json:"timeout" mapstructure:"timeout"`           // Execution timeout (default: 30s)
+	FailureMode FailureMode   `json:"failure_mode" mapstructure:"failure_mode"` // How to handle failures
+	RunMode     RunMode       `json:"run_mode" mapstructure:"run_mode"`         // Blocking or async execution
+}
+
+// FailureMode defines how to handle hook execution failures
+type FailureMode string
+
+const (
+	FailureModeIgnore FailureMode = "ignore" // Continue regardless of hook failure
+	FailureModeFail   FailureMode = "fail"   // Fail the entire operation if hook fails
+	FailureModeRetry  FailureMode = "retry"  // Retry the hook on failure
+)
+
+// RunMode defines how hooks are executed
+type RunMode string
+
+const (
+	RunModeBlocking RunMode = "blocking" // Wait for hook completion before continuing
+	RunModeAsync    RunMode = "async"    // Start hook and continue immediately
+)
+
+// Validate validates the lifecycle hooks configuration
+func (lh *LifecycleHooks) Validate() error {
+	// Check for duplicate hook names across all phases
+	hookNames := make(map[string]string) // name -> phase
+
+	phases := map[string][]Hook{
+		"pre_start":  lh.PreStart,
+		"post_start": lh.PostStart,
+		"pre_stop":   lh.PreStop,
+		"post_stop":  lh.PostStop,
+	}
+
+	for phase, hooks := range phases {
+		for i, hook := range hooks {
+			// Validate individual hook
+			if err := hook.Validate(); err != nil {
+				return fmt.Errorf("%s hook %d validation failed: %w", phase, i, err)
+			}
+
+			// Check for duplicate names
+			if existingPhase, exists := hookNames[hook.Name]; exists {
+				return fmt.Errorf("duplicate hook name %q found in %s and %s phases", hook.Name, existingPhase, phase)
+			}
+			hookNames[hook.Name] = phase
+		}
+
+		// Check phase-specific constraints
+		if len(hooks) > 50 {
+			return fmt.Errorf("%s phase has too many hooks (%d), maximum is 50", phase, len(hooks))
+		}
+	}
+
+	// Validate logical constraints
+	totalHooks := len(lh.PreStart) + len(lh.PostStart) + len(lh.PreStop) + len(lh.PostStop)
+	if totalHooks > 100 {
+		return fmt.Errorf("total hooks count %d exceeds maximum of 100", totalHooks)
+	}
+
+	// Warn about potentially problematic patterns
+	if len(lh.PreStart) > 10 {
+		// This is not an error, but could indicate complex setup
+	}
+
+	return nil
+}
+
+// Validate validates a single hook configuration
+func (h *Hook) Validate() error {
+	// Name is required for identification
+	name := strings.TrimSpace(h.Name)
+	if name == "" {
+		return fmt.Errorf("hook name is required")
+	}
+
+	// Name should not contain special characters that could cause issues
+	if strings.ContainsAny(name, " \t\n\r/\\<>:\"|?*") {
+		return fmt.Errorf("hook %q: name contains invalid characters (spaces, tabs, path separators, or special chars)", name)
+	}
+
+	// Command is required
+	if strings.TrimSpace(h.Command) == "" {
+		return fmt.Errorf("hook %q requires command", name)
+	}
+
+	// Command should not be excessively long
+	if len(h.Command) > 10000 {
+		return fmt.Errorf("hook %q: command too long (max 10000 characters)", name)
+	}
+
+	// Validate failure mode
+	switch h.FailureMode {
+	case "", FailureModeIgnore, FailureModeFail, FailureModeRetry:
+		// Valid
+	default:
+		return fmt.Errorf("hook %q: invalid failure_mode %q, must be one of: ignore, fail, retry", name, h.FailureMode)
+	}
+
+	// Validate run mode
+	switch h.RunMode {
+	case "", RunModeBlocking, RunModeAsync:
+		// Valid
+	default:
+		return fmt.Errorf("hook %q: invalid run_mode %q, must be one of: blocking, async", name, h.RunMode)
+	}
+
+	// Timeout should be positive if specified
+	if h.Timeout < 0 {
+		return fmt.Errorf("hook %q: timeout cannot be negative", name)
+	}
+
+	// Timeout should not be excessively long (max 1 hour)
+	if h.Timeout > time.Hour {
+		return fmt.Errorf("hook %q: timeout too long (max 1 hour)", name)
+	}
+
+	// Validate working directory if specified
+	if h.WorkDir != "" {
+		workDir := strings.TrimSpace(h.WorkDir)
+		if workDir == "" {
+			return fmt.Errorf("hook %q: work_dir cannot be empty string or whitespace", name)
+		}
+		// Check for potentially dangerous paths
+		if strings.Contains(workDir, "..") {
+			return fmt.Errorf("hook %q: work_dir cannot contain '..' path traversal", name)
+		}
+	}
+
+	// Validate environment variables
+	for i, env := range h.Env {
+		if !strings.Contains(env, "=") {
+			return fmt.Errorf("hook %q: env[%d] %q is invalid, must be in KEY=VALUE format", name, i, env)
+		}
+
+		parts := strings.SplitN(env, "=", 2)
+		key := strings.TrimSpace(parts[0])
+		if key == "" {
+			return fmt.Errorf("hook %q: env[%d] has empty key", name, i)
+		}
+
+		// Check for reserved environment variables
+		if strings.HasPrefix(key, "PROVISR_") {
+			return fmt.Errorf("hook %q: env[%d] key %q is reserved (PROVISR_ prefix)", name, i, key)
+		}
+	}
+
+	return nil
+}
+
+// GetDefaults applies default values to hook configuration
+func (h *Hook) GetDefaults() {
+	if h.FailureMode == "" {
+		h.FailureMode = FailureModeFail // Default to failing on hook errors
+	}
+
+	if h.RunMode == "" {
+		h.RunMode = RunModeBlocking // Default to blocking execution
+	}
+
+	if h.Timeout == 0 {
+		h.Timeout = 30 * time.Second // Default 30 second timeout
+	}
+}
+
+// HasAnyHooks returns true if there are any hooks defined
+func (lh *LifecycleHooks) HasAnyHooks() bool {
+	return len(lh.PreStart) > 0 || len(lh.PostStart) > 0 || len(lh.PreStop) > 0 || len(lh.PostStop) > 0
+}
+
+// GetHooksForPhase returns hooks for a specific lifecycle phase
+func (lh *LifecycleHooks) GetHooksForPhase(phase LifecyclePhase) []Hook {
+	switch phase {
+	case PhasePreStart:
+		return lh.PreStart
+	case PhasePostStart:
+		return lh.PostStart
+	case PhasePreStop:
+		return lh.PreStop
+	case PhasePostStop:
+		return lh.PostStop
+	default:
+		return nil
+	}
+}
+
+// LifecyclePhase represents different phases of process lifecycle
+type LifecyclePhase string
+
+const (
+	PhasePreStart  LifecyclePhase = "pre_start"
+	PhasePostStart LifecyclePhase = "post_start"
+	PhasePreStop   LifecyclePhase = "pre_stop"
+	PhasePostStop  LifecyclePhase = "post_stop"
+)
+
+// String returns the string representation of the lifecycle phase
+func (p LifecyclePhase) String() string {
+	return string(p)
+}
+
+// DeepCopy creates a deep copy of LifecycleHooks
+func (lh *LifecycleHooks) DeepCopy() LifecycleHooks {
+	if lh == nil {
+		return LifecycleHooks{}
+	}
+
+	hooks := LifecycleHooks{
+		PreStart:  copyHooks(lh.PreStart),
+		PostStart: copyHooks(lh.PostStart),
+		PreStop:   copyHooks(lh.PreStop),
+		PostStop:  copyHooks(lh.PostStop),
+	}
+
+	return hooks
+}
+
+// copyHooks creates a deep copy of a slice of hooks
+func copyHooks(hooks []Hook) []Hook {
+	if hooks == nil {
+		return nil
+	}
+
+	copied := make([]Hook, len(hooks))
+	for i, hook := range hooks {
+		copied[i] = hook.DeepCopy()
+	}
+
+	return copied
+}
+
+// DeepCopy creates a deep copy of a Hook
+func (h *Hook) DeepCopy() Hook {
+	hook := Hook{
+		Name:        h.Name,
+		Command:     h.Command,
+		WorkDir:     h.WorkDir,
+		Timeout:     h.Timeout,
+		FailureMode: h.FailureMode,
+		RunMode:     h.RunMode,
+	}
+
+	// Copy environment variables slice
+	if h.Env != nil {
+		hook.Env = append([]string(nil), h.Env...)
+	}
+
+	return hook
+}

--- a/internal/process/lifecycle_test.go
+++ b/internal/process/lifecycle_test.go
@@ -1,0 +1,457 @@
+package process
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHook_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		hook    Hook
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid hook",
+			hook: Hook{
+				Name:        "setup-db",
+				Command:     "echo 'setting up database'",
+				WorkDir:     "/app",
+				Env:         []string{"DB_HOST=localhost"},
+				Timeout:     30 * time.Second,
+				FailureMode: FailureModeFail,
+				RunMode:     RunModeBlocking,
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty name",
+			hook: Hook{
+				Command: "echo test",
+			},
+			wantErr: true,
+			errMsg:  "hook name is required",
+		},
+		{
+			name: "invalid name with spaces",
+			hook: Hook{
+				Name:    "setup db",
+				Command: "echo test",
+			},
+			wantErr: true,
+			errMsg:  "name contains invalid characters",
+		},
+		{
+			name: "invalid name with path separator",
+			hook: Hook{
+				Name:    "setup/db",
+				Command: "echo test",
+			},
+			wantErr: true,
+			errMsg:  "name contains invalid characters",
+		},
+		{
+			name: "empty command",
+			hook: Hook{
+				Name: "test",
+			},
+			wantErr: true,
+			errMsg:  "requires command",
+		},
+		{
+			name: "command too long",
+			hook: Hook{
+				Name:    "test",
+				Command: strings.Repeat("a", 10001),
+			},
+			wantErr: true,
+			errMsg:  "command too long",
+		},
+		{
+			name: "invalid failure mode",
+			hook: Hook{
+				Name:        "test",
+				Command:     "echo test",
+				FailureMode: "invalid",
+			},
+			wantErr: true,
+			errMsg:  "invalid failure_mode",
+		},
+		{
+			name: "invalid run mode",
+			hook: Hook{
+				Name:    "test",
+				Command: "echo test",
+				RunMode: "invalid",
+			},
+			wantErr: true,
+			errMsg:  "invalid run_mode",
+		},
+		{
+			name: "negative timeout",
+			hook: Hook{
+				Name:    "test",
+				Command: "echo test",
+				Timeout: -1 * time.Second,
+			},
+			wantErr: true,
+			errMsg:  "timeout cannot be negative",
+		},
+		{
+			name: "timeout too long",
+			hook: Hook{
+				Name:    "test",
+				Command: "echo test",
+				Timeout: 2 * time.Hour,
+			},
+			wantErr: true,
+			errMsg:  "timeout too long",
+		},
+		{
+			name: "work_dir with path traversal",
+			hook: Hook{
+				Name:    "test",
+				Command: "echo test",
+				WorkDir: "../etc",
+			},
+			wantErr: true,
+			errMsg:  "work_dir cannot contain '..' path traversal",
+		},
+		{
+			name: "empty work_dir",
+			hook: Hook{
+				Name:    "test",
+				Command: "echo test",
+				WorkDir: "   ",
+			},
+			wantErr: true,
+			errMsg:  "work_dir cannot be empty string or whitespace",
+		},
+		{
+			name: "invalid env format",
+			hook: Hook{
+				Name:    "test",
+				Command: "echo test",
+				Env:     []string{"INVALID_ENV"},
+			},
+			wantErr: true,
+			errMsg:  "must be in KEY=VALUE format",
+		},
+		{
+			name: "empty env key",
+			hook: Hook{
+				Name:    "test",
+				Command: "echo test",
+				Env:     []string{"=value"},
+			},
+			wantErr: true,
+			errMsg:  "has empty key",
+		},
+		{
+			name: "reserved env key",
+			hook: Hook{
+				Name:    "test",
+				Command: "echo test",
+				Env:     []string{"PROVISR_SECRET=value"},
+			},
+			wantErr: true,
+			errMsg:  "is reserved (PROVISR_ prefix)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.hook.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Hook.Validate() error = nil, wantErr %v", tt.wantErr)
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("Hook.Validate() error = %v, want to contain %v", err, tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Hook.Validate() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestHook_GetDefaults(t *testing.T) {
+	hook := &Hook{
+		Name:    "test",
+		Command: "echo test",
+	}
+
+	hook.GetDefaults()
+
+	if hook.FailureMode != FailureModeFail {
+		t.Errorf("GetDefaults() FailureMode = %v, want %v", hook.FailureMode, FailureModeFail)
+	}
+	if hook.RunMode != RunModeBlocking {
+		t.Errorf("GetDefaults() RunMode = %v, want %v", hook.RunMode, RunModeBlocking)
+	}
+	if hook.Timeout != 30*time.Second {
+		t.Errorf("GetDefaults() Timeout = %v, want %v", hook.Timeout, 30*time.Second)
+	}
+}
+
+func TestLifecycleHooks_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		hooks   LifecycleHooks
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid hooks",
+			hooks: LifecycleHooks{
+				PreStart: []Hook{
+					{Name: "setup", Command: "echo setup"},
+				},
+				PostStart: []Hook{
+					{Name: "notify", Command: "echo notify"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty hooks",
+			hooks:   LifecycleHooks{},
+			wantErr: false,
+		},
+		{
+			name: "duplicate hook names",
+			hooks: LifecycleHooks{
+				PreStart: []Hook{
+					{Name: "setup", Command: "echo setup1"},
+				},
+				PostStart: []Hook{
+					{Name: "setup", Command: "echo setup2"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "duplicate hook name",
+		},
+		{
+			name: "invalid hook in pre_start",
+			hooks: LifecycleHooks{
+				PreStart: []Hook{
+					{Name: "", Command: "echo test"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "pre_start hook 0 validation failed",
+		},
+		{
+			name: "too many hooks in one phase",
+			hooks: LifecycleHooks{
+				PreStart: make([]Hook, 51),
+			},
+			wantErr: true,
+			errMsg:  "pre_start phase has too many hooks",
+		},
+	}
+
+	// Initialize hooks for "too many hooks" test
+	for i := 0; i < 51; i++ {
+		tests[4].hooks.PreStart[i] = Hook{
+			Name:    "hook" + string(rune('a'+i%26)) + string(rune('0'+i/26)),
+			Command: "echo test",
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.hooks.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("LifecycleHooks.Validate() error = nil, wantErr %v", tt.wantErr)
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("LifecycleHooks.Validate() error = %v, want to contain %v", err, tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("LifecycleHooks.Validate() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestLifecycleHooks_HasAnyHooks(t *testing.T) {
+	tests := []struct {
+		name  string
+		hooks LifecycleHooks
+		want  bool
+	}{
+		{
+			name:  "no hooks",
+			hooks: LifecycleHooks{},
+			want:  false,
+		},
+		{
+			name: "has pre_start hooks",
+			hooks: LifecycleHooks{
+				PreStart: []Hook{{Name: "test", Command: "echo test"}},
+			},
+			want: true,
+		},
+		{
+			name: "has post_stop hooks",
+			hooks: LifecycleHooks{
+				PostStop: []Hook{{Name: "cleanup", Command: "echo cleanup"}},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.hooks.HasAnyHooks(); got != tt.want {
+				t.Errorf("LifecycleHooks.HasAnyHooks() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLifecycleHooks_GetHooksForPhase(t *testing.T) {
+	hooks := LifecycleHooks{
+		PreStart:  []Hook{{Name: "pre1", Command: "echo pre1"}},
+		PostStart: []Hook{{Name: "post1", Command: "echo post1"}},
+		PreStop:   []Hook{{Name: "prestop1", Command: "echo prestop1"}},
+		PostStop:  []Hook{{Name: "poststop1", Command: "echo poststop1"}},
+	}
+
+	tests := []struct {
+		phase    LifecyclePhase
+		expected int
+		hookName string
+	}{
+		{PhasePreStart, 1, "pre1"},
+		{PhasePostStart, 1, "post1"},
+		{PhasePreStop, 1, "prestop1"},
+		{PhasePostStop, 1, "poststop1"},
+		{"invalid", 0, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.phase), func(t *testing.T) {
+			result := hooks.GetHooksForPhase(tt.phase)
+			if len(result) != tt.expected {
+				t.Errorf("GetHooksForPhase(%v) returned %d hooks, want %d", tt.phase, len(result), tt.expected)
+			}
+			if tt.expected > 0 && result[0].Name != tt.hookName {
+				t.Errorf("GetHooksForPhase(%v) returned hook name %v, want %v", tt.phase, result[0].Name, tt.hookName)
+			}
+		})
+	}
+}
+
+func TestLifecycleHooks_DeepCopy(t *testing.T) {
+	original := LifecycleHooks{
+		PreStart: []Hook{
+			{
+				Name:    "setup",
+				Command: "echo setup",
+				Env:     []string{"KEY=value"},
+			},
+		},
+		PostStart: []Hook{
+			{
+				Name:    "notify",
+				Command: "echo notify",
+			},
+		},
+	}
+
+	copied := original.DeepCopy()
+
+	// Verify the copy is independent
+	copied.PreStart[0].Name = "modified"
+	copied.PreStart[0].Env[0] = "MODIFIED=value"
+
+	if original.PreStart[0].Name == "modified" {
+		t.Error("DeepCopy() did not create independent copy of Name")
+	}
+	if original.PreStart[0].Env[0] == "MODIFIED=value" {
+		t.Error("DeepCopy() did not create independent copy of Env slice")
+	}
+
+	// Verify structure is preserved
+	if len(copied.PreStart) != 1 {
+		t.Errorf("DeepCopy() PreStart length = %d, want 1", len(copied.PreStart))
+	}
+	if len(copied.PostStart) != 1 {
+		t.Errorf("DeepCopy() PostStart length = %d, want 1", len(copied.PostStart))
+	}
+}
+
+func TestHook_DeepCopy(t *testing.T) {
+	original := Hook{
+		Name:        "test",
+		Command:     "echo test",
+		WorkDir:     "/app",
+		Env:         []string{"KEY1=value1", "KEY2=value2"},
+		Timeout:     30 * time.Second,
+		FailureMode: FailureModeFail,
+		RunMode:     RunModeBlocking,
+	}
+
+	copied := original.DeepCopy()
+
+	// Modify the copy
+	copied.Name = "modified"
+	copied.Env[0] = "MODIFIED=value"
+
+	// Verify original is unchanged
+	if original.Name == "modified" {
+		t.Error("DeepCopy() did not create independent copy of Name")
+	}
+	if original.Env[0] == "MODIFIED=value" {
+		t.Error("DeepCopy() did not create independent copy of Env slice")
+	}
+
+	// Verify all fields are copied correctly
+	if copied.Command != original.Command {
+		t.Error("DeepCopy() did not copy Command correctly")
+	}
+	if copied.WorkDir != original.WorkDir {
+		t.Error("DeepCopy() did not copy WorkDir correctly")
+	}
+	if copied.Timeout != original.Timeout {
+		t.Error("DeepCopy() did not copy Timeout correctly")
+	}
+	if copied.FailureMode != original.FailureMode {
+		t.Error("DeepCopy() did not copy FailureMode correctly")
+	}
+	if copied.RunMode != original.RunMode {
+		t.Error("DeepCopy() did not copy RunMode correctly")
+	}
+}
+
+func TestLifecyclePhase_String(t *testing.T) {
+	tests := []struct {
+		phase    LifecyclePhase
+		expected string
+	}{
+		{PhasePreStart, "pre_start"},
+		{PhasePostStart, "post_start"},
+		{PhasePreStop, "pre_stop"},
+		{PhasePostStop, "post_stop"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.phase), func(t *testing.T) {
+			if got := tt.phase.String(); got != tt.expected {
+				t.Errorf("LifecyclePhase.String() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Implemented pre_start, post_start, pre_stop, post_stop phases
- Added validation (naming, limits, env, timeout, duplication)
- Integrated with Job & CronJob (with proper hook merging rules)
- Provided failure_mode, run_mode, timeout, env, work_dir options
- Added comprehensive unit & integration tests